### PR TITLE
[FIX] relation "utm_stage" does not exist [12.0->13.0]

### DIFF
--- a/addons/utm/models/utm.py
+++ b/addons/utm/models/utm.py
@@ -25,7 +25,7 @@ class UtmCampaign(models.Model):
         'res.users', string='Responsible',
         required=True, default=lambda self: self.env.uid)
     stage_id = fields.Many2one('utm.stage', string='Stage', ondelete='restrict', required=True,
-        default=lambda self: self.env['utm.stage'].search([], limit=1),
+        # default=lambda self: self.env['utm.stage'].search([], limit=1),
         group_expand='_group_expand_stage_ids')
     tag_ids = fields.Many2many(
         'utm.tag', 'utm_tag_rel',


### PR DESCRIPTION
Ref. #2317

Description of the issue/feature this PR addresses:

If only utm is installed in a v12 DB, the migration will fail with this error:
`relation "utm_stage" does not exist`


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
